### PR TITLE
fix: let's treat unstructured commit messages as PATCH versions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21,9 +21,12 @@ module.exports = function (pluginConfig, _ref, cb) {
 
   commits.map(function (commit) {
     return parseRawCommit(commit.hash + '\n' + commit.message);
-  }).filter(function (commit) {
-    return !!commit;
   }).every(function (commit) {
+    if (!commit) {
+      type = 'patch';
+      return true;
+    }
+
     if (commit.breaks.length) {
       type = 'major';
       return false;

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,12 @@ module.exports = function (pluginConfig, {commits}, cb) {
 
   .map((commit) => parseRawCommit(`${commit.hash}\n${commit.message}`))
 
-  .filter((commit) => !!commit)
-
   .every((commit) => {
+    if (!commit) {
+      type = 'patch'
+      return true
+    }
+
     if (commit.breaks.length) {
       type = 'major'
       return false

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -127,5 +127,19 @@ test('derive version number from commits', (t) => {
     })
   })
 
+  t.test('unstructured -> patch release', (tt) => {
+    tt.plan(2)
+
+    analyzer({}, {
+      commits: [{
+        hash: 'asdf',
+        message: 'add email notifications yo'
+      }]
+    }, (err, type) => {
+      tt.error(err)
+      tt.is(type, 'patch')
+    })
+  })
+
   t.end()
 })


### PR DESCRIPTION
this can work well for team transition time to Angular commit messages style - some unstructured commit messages can go through time to time, let's not skip version increase for these cases.
